### PR TITLE
Show timer in red for the last 7 seconds

### DIFF
--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimer.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimer.swift
@@ -100,6 +100,16 @@ class TOTPCountdownTimer: ObservableObject {
         timer = nil
     }
 
+    /// The preferred color of the timer based on the amount remaining
+    ///
+    func timerColor() -> SwiftUI.Color {
+        if secondsRemaining <= 7 {
+            Asset.Colors.loadingRed.swiftUIColor
+        } else {
+            Asset.Colors.primaryBitwarden.swiftUIColor
+        }
+    }
+
     /// Updates the countdown timer value.
     ///
     private func updateCountdown() {

--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerView.swift
@@ -34,7 +34,7 @@ struct TOTPCountdownTimerView: View {
         .background {
             CircularProgressShape(progress: timer.remainingFraction, clockwise: true)
                 .stroke(lineWidth: 3)
-                .foregroundColor(Asset.Colors.primaryBitwarden.swiftUIColor)
+                .foregroundColor(timer.timerColor())
                 .animation(
                     .smooth(
                         duration: TOTPCountdownTimerView.timerInterval


### PR DESCRIPTION
## 📔 Objective

This shows the timer for TOTP code expiration in red when it gets to 7 seconds or fewer remaining

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![Simulator Screenshot - iPhone 15 Pro - 2024-04-13 at 16 20 24](https://github.com/bitwarden/authenticator-ios/assets/159173170/ca0afe74-5948-45ca-84b4-4d0e84e373b7)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
