### PR TITLE
Move secret key to user defaults

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/ServiceContainer.swift
+++ b/AuthenticatorShared/Core/Platform/Services/ServiceContainer.swift
@@ -124,7 +124,7 @@ public class ServiceContainer: Services {
         let timeProvider = CurrentTime()
 
         let cryptographyKeyService = CryptographyKeyService(
-            keychainRepository: keychainRepository
+            stateService: stateService
         )
 
         let cryptographyService = DefaultCryptographyService(

--- a/AuthenticatorShared/Core/Platform/Services/StateService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/StateService.swift
@@ -23,6 +23,12 @@ protocol StateService: AnyObject {
     ///
     func getClearClipboardValue(userId: String?) async throws -> ClearClipboardValue
 
+    /// Gets the user's encryption secret key.
+    ///
+    /// - Returns: The user's encryption secret key.
+    ///
+    func getSecretKey(userId: String?) async throws -> String?
+
     /// Get whether to show website icons.
     ///
     /// - Returns: Whether to show the website icons.
@@ -46,6 +52,13 @@ protocol StateService: AnyObject {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String?) async throws
+
+    /// Sets the user's encryption secreet key.
+    ///
+    /// - Parameters:
+    ///   - key: The key to set
+    ///
+    func setSecretKey(_ key: String, userId: String?) async throws
 
     /// Set whether to show the website icons.
     ///
@@ -130,6 +143,11 @@ actor DefaultStateService: StateService {
         return appSettingsStore.clearClipboardValue(userId: userId)
     }
 
+    func getSecretKey(userId: String?) async throws -> String? {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.secretKey(userId: userId)
+    }
+
     func getShowWebIcons() async -> Bool {
         !appSettingsStore.disableWebIcons
     }
@@ -142,6 +160,11 @@ actor DefaultStateService: StateService {
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String?) async throws {
         let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setClearClipboardValue(clearClipboardValue, userId: userId)
+    }
+
+    func setSecretKey(_ key: String, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setSecretKey(key, userId: userId)
     }
 
     func setShowWebIcons(_ showWebIcons: Bool) async {

--- a/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -35,6 +35,13 @@ protocol AppSettingsStore: AnyObject {
     ///
     func clearClipboardValue(userId: String) -> ClearClipboardValue
 
+    /// Gets the user's secret encryption key.
+    ///
+    /// - Parameters:
+    ///   - userId: The user ID
+    ///
+    func secretKey(userId: String) -> String?
+
     /// Sets the time after which the clipboard should be cleared.
     ///
     /// - Parameters:
@@ -44,6 +51,14 @@ protocol AppSettingsStore: AnyObject {
     /// - Returns: The time after which the clipboard should be cleared.
     ///
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String)
+
+    /// Sets the user's secret encryption key.
+    ///
+    /// - Parameters:
+    ///   - key: The key to set
+    ///   - userId: The user ID
+    ///
+    func setSecretKey(_ key: String, userId: String)
 }
 
 // MARK: - DefaultAppSettingsStore
@@ -167,6 +182,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case disableWebIcons
         case hasSeenWelcomeTutorial
         case migrationVersion
+        case secretKey(userId: String)
 
         /// Returns the key used to store the data under for retrieving it later.
         var storageKey: String {
@@ -186,6 +202,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "hasSeenWelcomeTutorial"
             case .migrationVersion:
                 key = "migrationVersion"
+            case let .secretKey(userId):
+                key = "secretKey_\(userId)"
             }
             return "bwaPreferencesStorage:\(key)"
         }
@@ -224,6 +242,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         return .never
     }
 
+    func secretKey(userId: String) -> String? {
+        return fetch(for: .secretKey(userId: userId))
+    }
+
     var migrationVersion: Int {
         get { fetch(for: .migrationVersion) }
         set { store(newValue, for: .migrationVersion) }
@@ -231,5 +253,9 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String) {
         store(clearClipboardValue?.rawValue, for: .clearClipboardValue(userId: userId))
+    }
+
+    func setSecretKey(_ key: String, userId: String) {
+        store(key, for: .secretKey(userId: userId))
     }
 }


### PR DESCRIPTION
## 📔 Objective

This moves the location of the key used to encrypt the OTP secret from the Keychain to UserDefaults, because UserDefaults will back up and restore correctly with a new device.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
