### PR TITLE
Make page indicator blue

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/Appearance/UI.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Appearance/UI.swift
@@ -76,6 +76,8 @@ public enum UI {
         UITextView.appearance().backgroundColor = .clear
         UITextView.appearance().textContainerInset = .zero
         UITextView.appearance().textContainer.lineFragmentPadding = 0
+
+        UIPageControl.appearance().currentPageIndicatorTintColor = Asset.Colors.primaryBitwarden.color
     }
 
     /// Override SwiftGen's lookup function in order to determine the language manually.


### PR DESCRIPTION
## 📔 Objective

This makes the page indicator (on the tutorial view) blue.

## 📸 Screenshots

![Simulator Screenshot - iPhone 15 Pro - 2024-04-16 at 23 36 02](https://github.com/bitwarden/authenticator-ios/assets/159173170/b906fd82-641d-4be6-b653-21c2ed96674c)

![Simulator Screenshot - iPhone 15 Pro - 2024-04-16 at 23 36 12](https://github.com/bitwarden/authenticator-ios/assets/159173170/c18c1e57-ba8d-4559-9da8-1fc14d3971ad)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
