### PR TITLE
Bring in strings files for other languages

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/Appearance/UI.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Appearance/UI.swift
@@ -82,7 +82,12 @@ public enum UI {
 
     /// Override SwiftGen's lookup function in order to determine the language manually.
     public static func localizationFunction(key: String, table: String, fallbackValue: String) -> String {
-        Bundle.main.localizedString(forKey: key, value: fallbackValue, table: table)
+        if let languageCode = initialLanguageCode,
+           let path = Bundle(for: AppProcessor.self).path(forResource: languageCode, ofType: "lproj"),
+           let bundle = Bundle(path: path) {
+            return bundle.localizedString(forKey: key, value: fallbackValue, table: table)
+        }
+        return Bundle.main.localizedString(forKey: key, value: fallbackValue, table: table)
     }
 }
 

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/af.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/af.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ar.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ar.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "لا توجد أية عناصر في القائمة";
+"ToViewVerificationCodesUpgradeToPremium" = "لعرض رموز التحقق، الترقية إلى بريميوم";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "إضافة عامل المصادقة الثنائية إلى عنصر لعرض رموز التحقق";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "تسجيل الدخول إلى Bitwarden على iPhone الخاص بك لعرض رموز التحقق";
+"SyncingItemsContainingVerificationCodes" = "مزامنة العناصر التي تحتوي على رموز التحقق";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "ألغ قفل Bitwarden على iPhone الخاص بك لعرض رموز التحقق";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "إعداد Bitwarden لعرض العناصر التي تحتوي على رموز التحقق";
+"Search" = "بحث";
+"NoItemsFound" = "لم يتم العثور على أي عنصر";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "إعداد رمز مرور ساعة Apple من أجل استخدام Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/az.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/az.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Sadalanacaq heç bir element yoxdur";
+"ToViewVerificationCodesUpgradeToPremium" = "Doğrulama kodlarına baxmaq üçün premiuma yüksəldin";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Doğrulama kodlarına baxmaq üçün bir elementə 2 faktorlu kimlik doğrulama əlavə edin";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Doğrulama kodlarına baxmaq üçün iPhone-nunuzda Bitwarden-ə giriş edin";
+"SyncingItemsContainingVerificationCodes" = "Doğrulama kodlarını ehtiva edən elementlər sinxronlaşdırılır";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Doğrulama kodlarına baxmaq üçün iPhone-nunuzda Bitwarden-in kilidini açın";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Doğrulama kodlarını ehtiva edən elementlərə baxmaq üçün Bitwarden-i quraşdırın";
+"Search" = "Axtar";
+"NoItemsFound" = "Heç bir element tapılmadı";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Bitwarden-i istifadə etmək üçün Apple Watch parolunu quraşdırın";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/be.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/be.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "У спісе адсутнічаюць элементы";
+"ToViewVerificationCodesUpgradeToPremium" = "Для прагляду праверачных кодаў перайдзіце на прэміяльную версію";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Дадайце двухфактарную аўтэнтыфікацыю да элемента для прагляду праверачных кодаў";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Увайдзіце ў Bitwarden на сваім iPhone для прагляду праверачных кодаў";
+"SyncingItemsContainingVerificationCodes" = "Сінхранізацыя элементаў, якія змяшчаюць праверачныя коды";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Разблакіруйце Bitwarden на сваім iPhone для прагляду праверачных кодаў";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Наладзьце Bitwarden для прагляду элементаў, якія змяшчаюць праверачныя коды";
+"Search" = "Пошук";
+"NoItemsFound" = "Элементаў не знойдзена";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Наладзьце код доступу Apple Watch, каб выкарыстоўваць Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/bg.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/bg.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Няма елементи за показване";
+"ToViewVerificationCodesUpgradeToPremium" = "За да видите кодовете за потвърждаване, надградете до платен план";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Добавете двустепенно удостоверяване към елемент, за да видите кодовете за потвърждаване";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Впишете се в Битуорден на своя iPhone, за да видите кодовете за потвърждаване";
+"SyncingItemsContainingVerificationCodes" = "Синхронизиране на елементите съдържащи кодове за потвърждаване";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Отключете Битуорден на своя iPhone, за да видите кодовете за потвърждаване";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Настройте Битуорден, за да видите елементите съдържащи кодове за потвърждаване";
+"Search" = "Търсене";
+"NoItemsFound" = "Няма намерени елементи";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Настройте парола за Apple Watch, за да използвате Битуорден";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/bn.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/bn.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/bs.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/bs.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ca.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ca.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "No hi ha cap element per llistar";
+"ToViewVerificationCodesUpgradeToPremium" = "Per veure els codis de verificació, actualitzeu a premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Afegiu l'autenticació de dos factors a un element per veure els codis de verificació";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Inicieu sessió de Bitwarden al vostre iPhone per veure els codis de verificació";
+"SyncingItemsContainingVerificationCodes" = "Sincronització d'elements que contenen codis de verificació";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Desbloquegeu Bitwarden al vostre iPhone per veure els codis de verificació";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Configura Bitwarden per veure els elements que contenen codis de verificació";
+"Search" = "Cerca";
+"NoItemsFound" = "No s'ha trobat cap element";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Configura la contrasenya d'Apple Watch per utilitzar Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/cs.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/cs.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Žádné položky k zobrazení";
+"ToViewVerificationCodesUpgradeToPremium" = "Pro zobrazení ověřovacích kódů přejděte na předplatné Premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Pro zobrazení ověřovacích kódů přidete dvoufaktorové ověření pro položku";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Pro zobrazení ověřovacích kódů se přihlaste do Bitwardenu na Vašem iPhonu";
+"SyncingItemsContainingVerificationCodes" = "Synchronizování položek obsahujících ověřovací kódy";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Pro zobrazení ověřovacích kódů odemkněte Bitwarden na Vašem iPhonu";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Pro zobrazení položek obsahujících ověřovací kódy nastavte Bitwarden";
+"Search" = "Hledat";
+"NoItemsFound" = "Nebyly nalezeny žádné položky";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Abyste mohli používat Bitwarden, nastavte kód na Apple Watch";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/cy.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/cy.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Chwilio";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/da.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/da.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Der er ingen emner at vise";
+"ToViewVerificationCodesUpgradeToPremium" = "Opgradér til Premium for at se bekræftelseskoder";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Føj tofaktorgodkendelse til et element for at se bekræftelseskoderne";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log ind på Bitwarden på din iPhone for at se bekræftelseskoder";
+"SyncingItemsContainingVerificationCodes" = "Synker emner med bekræftelseskoder";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Oplås Bitwarden på din iPhone for at se bekræftelseskoder";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Opsæt Bitwarden for at se emner indeholdende bekræftelseskoder";
+"Search" = "Søgning";
+"NoItemsFound" = "Ingen emner fundet";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Opsæt Apple Watch-adgangskode for brug af Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/de.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/de.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Keine Einträge zum Anzeigen vorhanden";
+"ToViewVerificationCodesUpgradeToPremium" = "Um Verifizierungscodes anzuzeigen, upgrade auf Premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Füge eine Zwei-Faktor-Authentifizierung zu einem Eintrag hinzu, um die Verifizierungscodes anzuzeigen";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Melde dich bei Bitwarden auf deinem iPhone an, um Verifizierungscodes anzuzeigen";
+"SyncingItemsContainingVerificationCodes" = "Synchronisieren von Einträgen, die Verifizierungscodes enthalten";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Entsperre Bitwarden auf deinem iPhone, um Verifizierungscodes anzuzeigen";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Richte Bitwarden für die Anzeige von Einträgen mit Verifizierungscodes ein";
+"Search" = "Suche";
+"NoItemsFound" = "Keine Einträge gefunden";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Lege einen Apple Watch-Code fest, um Bitwarden zu verwenden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/el.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/el.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Δεν υπάρχουν στοιχεία στη λίστα";
+"ToViewVerificationCodesUpgradeToPremium" = "Για να δείτε τους κωδικούς επαλήθευσης, αναβαθμίστε σε premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Προσθέστε έλεγχο ταυτότητας 2 παραγόντων σε ένα στοιχείο για να δείτε τους κωδικούς επαλήθευσης";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Συνδεθείτε στο Bitwarden στο iPhone σας για να δείτε τους κωδικούς επαλήθευσης";
+"SyncingItemsContainingVerificationCodes" = "Συγχρονισμός στοιχείων που περιέχουν κωδικούς επαλήθευσης";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Ξεκλειδώστε το Bitwarden στο iPhone σας για να δείτε τους κωδικούς επαλήθευσης";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Ρυθμίστε το Bitwarden για να δείτε τα στοιχεία που περιέχουν κωδικούς επαλήθευσης";
+"Search" = "Αναζήτηση";
+"NoItemsFound" = "Δεν βρέθηκαν στοιχεία";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Ρυθμίστε κωδικό πρόσβασης στο Apple Watch για να χρησιμοποιήσετε Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en-GB.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en-GB.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en-IN.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en-IN.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/es.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/es.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "No hay elementos para listar";
+"ToViewVerificationCodesUpgradeToPremium" = "Para ver los códigos de verificación, mejora a prémium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Añade autenticación de 2 pasos a un elemento para ver los códigos de verificación";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Inicia sesión en Bitwarden en tu iPhone para ver los códigos de verificación";
+"SyncingItemsContainingVerificationCodes" = "Sincronizando elementos que contienen códigos de verificación";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Desbloquea Bitwarden en tu iPhone para ver los códigos de verificación";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Configurar Bitwarden para ver los elementos que contienen códigos de verificación";
+"Search" = "Buscar";
+"NoItemsFound" = "No se encontraron elementos";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Configurar la contraseña de Apple Watch para usar Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/et.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/et.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Puuduvad kirjed, mida kuvada";
+"ToViewVerificationCodesUpgradeToPremium" = "Kinnituskoodide nägemiseks on vajalik Premium versioon";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/eu.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/eu.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/fa.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/fa.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "هیچ موردی برای نمایش وجود ندارد";
+"ToViewVerificationCodesUpgradeToPremium" = "برای مشاهده کدهای تأیید، به پرمیوم ارتقا دهید";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "برای مشاهده کدهای تأیید، احراز هویت دو عاملی را به یک مورد اضافه کنید";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "برای مشاهده کدهای تأیید در آیفون خود وارد Bitwarden شوید";
+"SyncingItemsContainingVerificationCodes" = "همگام‌سازی موارد حاوی کدهای تأیید";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "برای مشاهده کدهای تأیید، قفل Bitwarden را در آیفون خود باز کنید";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Bitwarden را برای مشاهده موارد حاوی کدهای تأیید تنظیم کنید";
+"Search" = "جستجو";
+"NoItemsFound" = "موردی یافت نشد";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "برای استفاده از Bitwarden، رمز عبور Apple Watch را تنظیم کنید";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/fi.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/fi.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Näytettäviä kohteita ei ole.";
+"ToViewVerificationCodesUpgradeToPremium" = "Näytä vahvistuskoodit päivittämällä Premiumiin.";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Näytä vahvistuskoodit lisäämällä kohteeseen kaksivaiheinen todennus.";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Näytä vahvistuskoodit kirjautumalla Bitwardeniin iPhonessa.";
+"SyncingItemsContainingVerificationCodes" = "Vahvistuskoodeja sisältäviä kohteita synkronoidaan.";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Näytä vahvistuskoodit avaamalla Bitwarden iPhonessa.";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Määritä Bitwarden nähdäksesi vahvistuskoodeja sisältävät kohteet.";
+"Search" = "Haku";
+"NoItemsFound" = "Kohteita ei löytynyt.";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Määritä Apple Watch -lukituskoodi Bitwardenin käyttämiseksi.";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/fil.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/fil.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/fr.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/fr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Aucun élément à afficher";
+"ToViewVerificationCodesUpgradeToPremium" = "Pour afficher les codes de vérification, passez à la version premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Ajouter l'authentification à 2 facteurs à un élément pour afficher les codes de vérification";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Connectez-vous à Bitwarden sur votre iPhone pour afficher les codes de vérification";
+"SyncingItemsContainingVerificationCodes" = "Synchronisation des éléments contenant des codes de vérification";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Débloquez Bitwarden sur votre iPhone pour afficher les codes de vérification";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Configurez Bitwarden pour afficher les éléments contenant des codes de vérification";
+"Search" = "Rechercher";
+"NoItemsFound" = "Aucun élément trouvé";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Configurez le mot de passe Apple Watch pour utiliser Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/gl.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/gl.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/he.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/he.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/hi.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/hi.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "वेरीफिकेशन कोड देखने के लिए अपने आईफोन पे बिटवार्डन में लॉगइन करें";
+"SyncingItemsContainingVerificationCodes" = "वेरीफिकेशन कोड वाले चीज़ें सिंक कर रहे";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "वेरीफिकेशन कोड देखने के लिए अपने आईफोन पे बिटवार्डन खोलें";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "वेरीफिकेशन कोड वाले चीज़ें देखने के लिए बिटवार्डन सेट करें";
+"Search" = "सर्च करें";
+"NoItemsFound" = "कोई आइटम नहीं मिला";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "बिटवार्डन इस्तेमाल करने के लिए एप्पल वॉच पासकोड सेट करें";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/hr.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/hr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Nema stavki za prikaz";
+"ToViewVerificationCodesUpgradeToPremium" = "Potrebno je premium članstvo za prikaz verifikacijskih kodova,";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Dodaj dvofaktorsku autentifikaciju za prikaz verifikacijskih kodova";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Prijavi se u Bitwarden na svojem iPhoneu za prikaz verifikacijskih kodova";
+"SyncingItemsContainingVerificationCodes" = "Sinkronizacija stavki koje sadrže verifikacijske kodove";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Otključaj Bitwarden na svojem iPhoneu za prikaz verifikacijskih kodova";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Podesi Bitwarden za prikaz stavki koje sadrže verifikacijske kodove";
+"Search" = "Traži";
+"NoItemsFound" = "Nije pronađena niti jedna stavka";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Za korištenje Bitwardena, podesi Apple Watch lozinku";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/hu.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/hu.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Nincsenek listázandó elemek.";
+"ToViewVerificationCodesUpgradeToPremium" = "Az ellenőrző kódok megtekintéséhez térjünk át a prémium csomagra.";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Adjunk hozzá kéttényezős hitelesítést egy elemnél az ellenőrző kódok megtekintéséhez.";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Az ellenőrző kódok megtekintéséhez jelentkezzünk be a Bitwardenbe az iPhone-on.";
+"SyncingItemsContainingVerificationCodes" = "Ellenőrző kódokat tartalmazó elemek szinkronizálása";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Oldjuk fel a Bitwarden zárolását az iPhone-on az ellenőrző kódok megtekintéséhez.";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "A Bitwarden beállítása az ellenőrző kódokat tartalmazó elemek megtekintéséhez";
+"Search" = "Keresés";
+"NoItemsFound" = "Nem található elem.";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Állítsuk be az Apple Watch jelszót a Bitwarden használatához.";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/id.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/id.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Tidak ada item untuk dicantumkan";
+"ToViewVerificationCodesUpgradeToPremium" = "Untuk melihat kode verifikasi, tingkatkan ke premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Menambahkan autentikasi 2 faktor ke item untuk melihat kode verifikasi";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Masuk ke Bitwarden di iPhone Anda untuk melihat kode verifikasi";
+"SyncingItemsContainingVerificationCodes" = "Menyinkronkan item yang berisi kode verifikasi";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Buka kunci Bitwarden di iPhone Anda untuk melihat kode verifikasi";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Mengatur Bitwarden untuk melihat item yang mengandung kode verifikasi";
+"Search" = "Pencarian";
+"NoItemsFound" = "Item tidak ditemukan";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Mengatur kode sandi Apple Watch untuk menggunakan Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/it.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/it.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Non ci sono elementi da mostrare";
+"ToViewVerificationCodesUpgradeToPremium" = "Per visualizzare i codici di verifica, passa a Premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Aggiungi la verifica in due passaggi a un elemento per visualizzare i codici di verifica";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Accedi a Bitwarden sul tuo iPhone per visualizzare i codici di verifica";
+"SyncingItemsContainingVerificationCodes" = "Sincronizzazione elementi con codici di verifica in corso...";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Sblocca Bitwarden sul tuo iPhone per visualizzare i codici di verifica";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Configura Bitwarden per visualizzare gli elementi contenenti codici di verifica";
+"Search" = "Cerca";
+"NoItemsFound" = "Nessun elemento trovato";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Imposta un codice per l'Apple Watch per usare Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ja.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ja.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "表示するアイテムがありません";
+"ToViewVerificationCodesUpgradeToPremium" = "認証コードを表示するには、プレミアムにアップグレードしてください";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "認証コードを表示するために、アイテムに二要素認証を追加します";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "認証コードを表示するにはあなたの iPhone で Bitwarden にログインしてください";
+"SyncingItemsContainingVerificationCodes" = "認証コードを含むアイテムを同期中";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "認証コードを表示するには、iPhone で Bitwarden をロック解除してください";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "認証コードを含んだアイテムを表示するには Bitwarden をセットアップしてください";
+"Search" = "検索";
+"NoItemsFound" = "アイテムが見つかりません";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Bitwarden を使うには Apple Watch のパスコードを設定してください";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ka.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ka.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/kn.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/kn.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ko.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ko.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/lt.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/lt.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/lv.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/lv.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Nav vienumu, ko ievietot sarakstā";
+"ToViewVerificationCodesUpgradeToPremium" = "Jāuzlabo uz Premium, lai apskatītu apliecinājuma kodus";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Vienumam jāpievieno divpakāpju apliecināšana, lai apskatītu apliecinājuma kodus";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Jāpiesakās Bitwarden iPhone, lai apskatītu apliecinājuma kodus";
+"SyncingItemsContainingVerificationCodes" = "Sinhronizē vienumus, kas satur apliecinājuma kodus";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Jāatslēdz Bitwarden iPhone, lai apskatītu apliecinājuma kodus";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Jāuzstāda Bitwarden, lai apskatītu vienumus, kas satur apliecinājuma kodus";
+"Search" = "Meklēt";
+"NoItemsFound" = "Netika atrasti vienumi";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Jāuzstāda Apple Watch paroles vārdkopa, lai varētu izmantot Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ml.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ml.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/mr.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/mr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "दाखवण्यासाठी एकही वस्तू नाही";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "शोध";
+"NoItemsFound" = "कोणत्याही वस्तू सापडल्या नाहीत";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/my.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/my.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/nb.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/nb.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ne.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ne.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/nl.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/nl.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Er zijn geen items om weer te geven";
+"ToViewVerificationCodesUpgradeToPremium" = "Upgrade naar premium om verificatiecodes te bekijken";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Voeg tweestapsverificatie toe aan een item voor het weergeven van verificatiecodes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in op Bitwarden op je iPhone voor het weergeven van verificatiecodes";
+"SyncingItemsContainingVerificationCodes" = "Synchroniseer items die verificatiecodes bevatten";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Ontgrendel Bitwarden op je iPhone voor het weergeven van verificatiecodes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Bitwarden instellen voor het weergeven van item met verificatie codes op je iPhone";
+"Search" = "Zoeken";
+"NoItemsFound" = "Geen items gevonden";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Stel een pincode op je Apple Watch in om Bitwarden te gebruiken";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/nn.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/nn.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Det er ingen oppføringar å visa";
+"ToViewVerificationCodesUpgradeToPremium" = "For å sjå verifiseringskodar, oppgrader til premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Legg til 2-faktorautentisering på eit element for å vise verifiseringskodane";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Logg på Bitwarden på din iPhone for å sjå verifiseringskodar";
+"SyncingItemsContainingVerificationCodes" = "Synkroniserer element som inneheld verifiseringskodar";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Lås opp Bitwarden på din iPhone for å sjå verifiseringskodar";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Sett opp Bitwarden for å sjå artiklar som inneheld verifiseringskodar";
+"Search" = "Søk";
+"NoItemsFound" = "Ingen funne";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Konfigurer Apple Watch-passkode for å bruke Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/or.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/or.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/pl.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/pl.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Brak elementów do wyświetlenia";
+"ToViewVerificationCodesUpgradeToPremium" = "Aby wyświetlić kody weryfikacyjne, uaktualnij do wersji premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Dodaj uwierzytelnianie dwuskładnikowe do elementu, aby wyświetlić kody weryfikacyjne";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Zaloguj się do Bitwarden na swoim iPhone, aby wyświetlić kody weryfikacyjne";
+"SyncingItemsContainingVerificationCodes" = "Synchronizowanie elementów zawierających kody weryfikacyjne";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Odblokuj Bitwarden na swoim iPhone, aby wyświetlić kody weryfikacyjne";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Skonfiguruj Bitwarden, aby wyświetlić elementy zawierające kody weryfikacyjne";
+"Search" = "Szukaj";
+"NoItemsFound" = "Nie znaleziono żadnych pozycji";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Skonfiguruj hasło Apple Watch w celu korzystania z Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/pt-BR.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Não há itens para listar";
+"ToViewVerificationCodesUpgradeToPremium" = "Para ver os códigos de verificação, atualize para premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Adicione autenticação de 2 fatores a um item para ver os códigos de verificação";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Entre no Bitwarden no seu iPhone para ver os códigos de verificação";
+"SyncingItemsContainingVerificationCodes" = "Sincronizando itens contendo códigos de verificação";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Desbloqueie o Bitwarden no seu iPhone para ver os códigos de verificação";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Configure o Bitwarden para ver itens contendo códigos de verificação";
+"Search" = "Pesquisar";
+"NoItemsFound" = "Nenhum item encontrado";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Configure a senha do Apple Watch para utilizar o Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/pt-PT.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/pt-PT.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Não há itens a enumerar";
+"ToViewVerificationCodesUpgradeToPremium" = "Para ver os códigos de verificação, atualize para o Premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Adicione a autenticação de 2 fatores a um item para ver os códigos de verificação";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Inicie sessão no Bitwarden no seu iPhone para ver os códigos de verificação";
+"SyncingItemsContainingVerificationCodes" = "A sincronizar itens com códigos de verificação";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Desbloqueie o Bitwarden no seu iPhone para ver os códigos de verificação";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Configure o Bitwarden para visualizar itens que contenham códigos de verificação";
+"Search" = "Procurar";
+"NoItemsFound" = "Nenhum item encontrado";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Configure o código de acesso do Apple Watch para utilizar o Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ro.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ro.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ru.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ru.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Нет элементов для отображения";
+"ToViewVerificationCodesUpgradeToPremium" = "Для просмотра кодов подтверждения перейдите на Премиум";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Добавить двухэтапную аутентификацию к элементу для отображения кодов подтверждения";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Войдите в Bitwarden на вашем iPhone, для просмотра кодов подтверждения";
+"SyncingItemsContainingVerificationCodes" = "Синхронизация элементов, содержащих коды подтверждения";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Разблокируйте Bitwarden на вашем iPhone, для просмотра кодов подтверждения";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Настроить Bitwarden для просмотра элементов, содержащих коды подтверждения";
+"Search" = "Поиск";
+"NoItemsFound" = "Элементов не найдено";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Установите код доступа Apple Watch для использования Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/si.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/si.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/sk.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/sk.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Neexistujú žiadne položky na zobrazenie";
+"ToViewVerificationCodesUpgradeToPremium" = "Ak chcete zobraziť overovacie kódy, prejdite na prémium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Ak chcete zobraziť overovacie kódy, pridajte k položke dvojfaktorové overenie";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Prihláste sa do Bitwardenu na iPhone a zobrazte si overovacie kódy";
+"SyncingItemsContainingVerificationCodes" = "Synchronizácia položiek obsahujúcich overovacie kódy";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Ak chcete zobraziť overovacie kódy, odomknite na svojom iPhone Bitwarden";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Nastavte Bitwarden na zobrazenie položiek obsahujúcich overovacie kódy";
+"Search" = "Hladať";
+"NoItemsFound" = "Nenašli sa žiadne položky";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Ak chcete používať Bitwarden, nastavte prístupový kód Apple Watch";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/sl.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/sl.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/sr.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/sr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Нема ставке у листи";
+"ToViewVerificationCodesUpgradeToPremium" = "Да бисте видели верификационе кодове, надоградите на премиум";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Додајте двофакторску аутентификацију ставки да бисте видели верификационе кодове";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Пријавите се на Bitwarden на iPhone-у да би видели верикикационе кодове";
+"SyncingItemsContainingVerificationCodes" = "Синхронизују се ставке које садрже верификационе кодове";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Деблокирајте Bitwarden на iPhone-у да би видели верикикационе кодове";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Подесите Bitwarden да видите ставке које садрже верификационе кодове";
+"Search" = "Тражи";
+"NoItemsFound" = "Нема предмета";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Подесите „Apple Watch passcode“ да бисте употребили Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/sv.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/sv.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Det finns inga objekt att visa";
+"ToViewVerificationCodesUpgradeToPremium" = "Uppgradera till Premium för att visa verifieringskoder";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Lägg till tvåfaktorsautentisering på ett objekt för att visa verifieringskoderna";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Logga in på Bitwarden på din iPhone för att visa verifieringskoder";
+"SyncingItemsContainingVerificationCodes" = "Synkroniserar objekt som innehåller verifieringskoder";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Lås upp Bitwarden på din iPhone för att visa verifieringskoder";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Ställ in Bitwarden för att visa objekt som innehåller verifieringskoder";
+"Search" = "Sök";
+"NoItemsFound" = "Inga objekt hittades";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Ställ in lösenkod på Apple Watch för att använda Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ta.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/ta.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "பட்டியலிட உருப்படிகளில்லை";
+"ToViewVerificationCodesUpgradeToPremium" = "சரிபார்ப்புக் குறியீடுகளைப் பார்க்க, உயர்தரத்திற்கு தரமுயர்த்துக";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "சரிபார்ப்புக் குறியீடுகளைப் பார்க்க ஓர் உருப்படிக்கு இருபடி அங்கீகரிப்பைச் சேர்";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "சரிபார்ப்புக் குறியீடுகளைப் பார்க்க உமது ஐஃபோனில் Bitwarden இல் உள்நுழைக";
+"SyncingItemsContainingVerificationCodes" = "சரிபார்ப்புக் குறியீடுகள் கொண்ட உருப்படிகளை ஒத்திசைக்கிறது";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "சரிபார்ப்புக் குறியீடுகளைப் பார்க்க உமது ஐஃபோனில் Bitwarden-ஐப் பூட்டவிழ்";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "சரிபார்ப்புக் குறியீடுகள் கொண்ட உருப்படிகளைப் பார்க்க Bitwarden-ஐ அமைத்திடுக";
+"Search" = "தேடு";
+"NoItemsFound" = "உருப்படிகள் எதுவும் இல்லை";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Bitwarden-ஐப் பயன்படுத்த ஆப்பிள் கடிகாரம் கடவுக்குறியை அமைத்திடுக";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/te.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/te.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/th.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/th.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "There are no items to list";
+"ToViewVerificationCodesUpgradeToPremium" = "To view verification codes, upgrade to premium";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Add 2 factor authentication to an item to view the verification codes";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Log in to Bitwarden on your iPhone to view verification codes";
+"SyncingItemsContainingVerificationCodes" = "Syncing items containing verification codes";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Unlock Bitwarden on your iPhone to view verification codes";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Set up Bitwarden to view items containing verification codes";
+"Search" = "Search";
+"NoItemsFound" = "No items found";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/tr.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/tr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Listelenecek kayıt yok";
+"ToViewVerificationCodesUpgradeToPremium" = "Doğrulama kodlarını görmek için premium'a geçin";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Doğrulama kodlarını görmek istediğiniz kayda iki aşamalı doğrulama ekleyin";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Doğrulama kodlarını görmek için Bitwarden'a iPhone'unuzdan giriş yapın";
+"SyncingItemsContainingVerificationCodes" = "Doğrulama kodları içeren kayıtlar eşitleniyor";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Doğrulama kodlarını görmek için iPhone'unuzda Bitwarden'ın kilidini açın";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Doğrulama kodu içeren kayıtları görmek için Bitwarden'ı ayarlayın";
+"Search" = "Arama";
+"NoItemsFound" = "Hiç kayıt bulunamadı";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Bitwarden'ı kullanmak için Apple Watch parolasını ayarlayın";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/uk.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/uk.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Немає записів для показу";
+"ToViewVerificationCodesUpgradeToPremium" = "Щоб отримати доступ до кодів підтвердження, передплатіть преміум";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Щоб переглядати коди підтвердження, додайте двоетапну перевірку до запису";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Увійдіть у Bitwarden на своєму iPhone, щоб отримати доступ до кодів підтвердження";
+"SyncingItemsContainingVerificationCodes" = "Триває синхронізація записів з кодами підтвердження";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Розблокуйте Bitwarden на своєму iPhone, щоб отримати доступ до кодів підтвердження";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Налаштуйте Bitwarden, щоб побачити записи з кодами підтвердження";
+"Search" = "Пошук";
+"NoItemsFound" = "Нічого не знайдено";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Налаштуйте код допуску Apple Watch, щоб використовувати Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/vi.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/vi.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "Không có mục nào";
+"ToViewVerificationCodesUpgradeToPremium" = "Dùng gói Cao Cấp để xem mã xác minh";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "Thêm xác minh 2 yếu tố vào một mục để xem mã xác minh";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "Đăng nhập Bitwarden trên iPhone của bạn để xem mã xác minh";
+"SyncingItemsContainingVerificationCodes" = "Đồng bộ các mục có chứa mã xác minh";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "Mở khóa Bitwarden trên iPhone của bạn để xem mã xác minh";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "Thiết lập Bitwarden để xem các mục chứa mã xác minh";
+"Search" = "Tìm kiếm";
+"NoItemsFound" = "Không tìm thấy mục nào";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Thiết lập Apple Watch passcode để dùng Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "没有要列出的项目";
+"ToViewVerificationCodesUpgradeToPremium" = "要查看验证码，请升级到高级版";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "将双因素身份验证添加到项目以查看验证码";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "登录您 iPhone 上的 Bitwarden 以查看验证码";
+"SyncingItemsContainingVerificationCodes" = "正在同步包含验证码的项目";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "解锁您 iPhone 上的 Bitwarden 以查看验证码";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "设置 Bitwarden 以查看包含验证码的项目";
+"Search" = "搜索";
+"NoItemsFound" = "未找到任何条目";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "设置 Apple Watch 通行代码以使用 Bitwarden";

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"ThereAreNoItemsToList" = "沒有可列出的項目。";
+"ToViewVerificationCodesUpgradeToPremium" = "請升級到 Premium 版，才能檢視驗證碼";
+"Add2FactorAutenticationToAnItemToViewVerificationCodes" = "為項目加入雙因素驗證機制，即可檢視驗證碼";
+"LogInToBitwardenOnYourIPhoneToViewVerificationCodes" = "在您的 iPhone 登入 Bitwarden 即可檢視驗證碼";
+"SyncingItemsContainingVerificationCodes" = "同步含有驗證碼的項目";
+"UnlockBitwardenOnYourIPhoneToViewVerificationCodes" = "解鎖您的 iPhone 上的 Bitwarden 即可檢視驗證碼";
+"SetUpBitwardenToViewItemsContainingVerificationCodes" = "設定 Bitwarden 即可檢視含有驗證碼的項目";
+"Search" = "搜尋";
+"NoItemsFound" = "找不到任何項目";
+"SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "設定 Apple Watch 解鎖碼即可使用 Bitwarden";


### PR DESCRIPTION
## 📔 Objective

This brings in strings files for other languages, so that changing the language is handled. However, we'll still need to set up Crowdin sync to bring in the full set later.

## 📸 Screenshots

(Note that only the "search" string is currently translated)

![Simulator Screenshot - iPhone 15 Pro - 2024-04-17 at 16 52 46](https://github.com/bitwarden/authenticator-ios/assets/159173170/213a750e-3f90-4ed1-9b11-7955301eae23)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
