### PR TITLE
Use username instead of account name

### DIFF
--- a/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemView.swift
+++ b/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemView.swift
@@ -76,7 +76,7 @@ struct EditAuthenticatorItemView: View {
             .textFieldConfiguration(.password)
 
             BitwardenTextField(
-                title: Localizations.accountName,
+                title: Localizations.username,
                 text: store.binding(
                     get: \.accountName,
                     send: EditAuthenticatorItemAction.accountNameChanged


### PR DESCRIPTION
## 📔 Objective

Changes the edit screen to say "username" instead of "account name"

## 📸 Screenshots

![Simulator Screenshot - iPhone 15 Pro - 2024-04-17 at 22 32 47](https://github.com/bitwarden/authenticator-ios/assets/159173170/b4e7f5fd-4620-49fd-906b-c076476b56d7)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
