### PR TITLE
Allow user to clear secret field

### DIFF
--- a/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemProcessor.swift
@@ -91,6 +91,7 @@ final class EditAuthenticatorItemProcessor: StateProcessor<
         case let .periodChanged(period):
             state.period = period
         case let .secretChanged(secret):
+            state.secret = secret
             state.totpState = LoginTOTPState(secret)
         case let .toggleSecretVisibilityChanged(isVisible):
             state.isSecretVisible = isVisible
@@ -130,6 +131,8 @@ final class EditAuthenticatorItemProcessor: StateProcessor<
         do {
             try EmptyInputValidator(fieldName: Localizations.name)
                 .validate(input: state.issuer)
+            try EmptyInputValidator(fieldName: Localizations.authenticatorKey)
+                .validate(input: state.secret)
             coordinator.showLoadingOverlay(title: Localizations.saving)
             switch state.configuration {
             case .add:


### PR DESCRIPTION
## 📔 Objective

This allows the user to clear the secret field. It also does not allow the user to save an item if the secret field is empty.

## 📸 Screenshots

![Simulator Screenshot - iPhone 15 Pro - 2024-04-23 at 12 13 35](https://github.com/bitwarden/authenticator-ios/assets/159173170/460a41bf-1e57-4283-ad27-dce3ae2240b3)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
