### PR TITLE
Allow fallback to device credentials when biometrics fails

### DIFF
--- a/AuthenticatorShared/Core/Auth/Services/KeychainRepository.swift
+++ b/AuthenticatorShared/Core/Auth/Services/KeychainRepository.swift
@@ -15,7 +15,7 @@ enum KeychainItem: Equatable {
     var protection: SecAccessControlCreateFlags? {
         switch self {
         case .biometrics:
-            .biometryCurrentSet
+            .userPresence
         case .secretKey:
             nil
         }


### PR DESCRIPTION
## 📔 Objective

Allow users to unlock with their device credential in cases when biometrics fails or is unavailable.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
