### PR TITLE
[BWA-1] Remove biometrics integrity check so users don't get locked out

### DIFF
--- a/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockProcessor.swift
+++ b/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockProcessor.swift
@@ -69,10 +69,9 @@ class VaultUnlockProcessor: StateProcessor<
     private func loadData() async {
         state.biometricUnlockStatus = await (try? services.biometricsRepository.getBiometricUnlockStatus())
             ?? .notAvailable
-        // If biometric unlock is available, enabled,
-        // and the user's biometric integrity state is valid;
+        // If biometric unlock is available and enabled
         // attempt to unlock the vault with biometrics once.
-        if case .available(_, true, true) = state.biometricUnlockStatus,
+        if case .available(_, true, _) = state.biometricUnlockStatus,
            shouldAttemptAutomaticBiometricUnlock {
             shouldAttemptAutomaticBiometricUnlock = false
             await unlockWithBiometrics()
@@ -83,9 +82,8 @@ class VaultUnlockProcessor: StateProcessor<
     ///
     private func unlockWithBiometrics() async {
         let status = try? await services.biometricsRepository.getBiometricUnlockStatus()
-        guard case let .available(_, enabled: enabled, hasValidIntegrity) = status,
-              enabled,
-              hasValidIntegrity else {
+        guard case let .available(_, enabled: enabled, _) = status,
+              enabled else {
             await loadData()
             return
         }


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-1](https://bitwarden.atlassian.net/browse/BWA-1)

## 📔 Objective

This removes the biometrics integrity check before asking for them—this prevents users from getting locked out if they e.g. reset their FaceID

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-1]: https://bitwarden.atlassian.net/browse/BWA-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ