### PR TITLE
[BWA-38] Make imported 2FAS fields optional

### DIFF
--- a/AuthenticatorShared/Core/Vault/Services/Fixtures/TwoFasExport.2fas
+++ b/AuthenticatorShared/Core/Vault/Services/Fixtures/TwoFasExport.2fas
@@ -53,7 +53,6 @@
                 "period": 60,
                 "source": "link",
                 "issuer": "Issuer2",
-                "account": "",
                 "tokenType": "TOTP",
                 "algorithm": "SHA256",
                 "digits": 8,

--- a/AuthenticatorShared/Core/Vault/Services/Importers/GoogleImporter.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Importers/GoogleImporter.swift
@@ -19,8 +19,9 @@ class GoogleImporter {
         return payload.otpParameters.compactMap { item in
             guard item.type == .otpTotp else { return nil }
             let secret = item.secret.base32String()
-            // Google Authenticator current ignores algorithm and period on all platforms and digits on some platforms (but not iOS).
-            // Therefore, we need to use defaults and keep the digits in a reasonable range, because Google Authenticator doesn't
+            // Google Authenticator current ignores algorithm and period on all platforms
+            // and digits on some platforms (but not iOS). Therefore, we need to use defaults
+            // and keep the digits in a reasonable range, because Google Authenticator doesn't
             // always provide a valid value.
             let otp = OTPAuthModel(
                 accountName: item.name.nilIfEmpty,

--- a/AuthenticatorShared/Core/Vault/Services/Importers/TwoFasImporter.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Importers/TwoFasImporter.swift
@@ -8,11 +8,11 @@ class TwoFasImporter {
             switch service.otp.tokenType {
             case "TOTP":
                 let otp = OTPAuthModel(
-                    accountName: service.otp.account.nilIfEmpty,
-                    algorithm: TOTPCryptoHashAlgorithm(rawValue: service.otp.algorithm) ?? .sha1,
-                    digits: service.otp.digits,
+                    accountName: service.otp.account,
+                    algorithm: TOTPCryptoHashAlgorithm(from: service.otp.algorithm),
+                    digits: service.otp.digits ?? 6,
                     issuer: service.otp.issuer ?? service.name,
-                    period: service.otp.period,
+                    period: service.otp.period ?? 30,
                     secret: service.secret
                 )
                 return AuthenticatorItemView(
@@ -20,7 +20,7 @@ class TwoFasImporter {
                     id: UUID().uuidString,
                     name: service.name,
                     totpKey: otp.otpAuthUri,
-                    username: service.otp.account.nilIfEmpty
+                    username: service.otp.account
                 )
             case "STEAM":
                 return AuthenticatorItemView(
@@ -28,7 +28,7 @@ class TwoFasImporter {
                     id: UUID().uuidString,
                     name: service.name,
                     totpKey: "steam://\(service.secret)",
-                    username: service.otp.account.nilIfEmpty
+                    username: service.otp.account
                 )
             default:
                 return nil
@@ -48,10 +48,10 @@ struct TwoFasService: Codable {
 }
 
 struct TwoFasOtp: Codable {
-    let account: String
-    let algorithm: String
-    let digits: Int
+    let account: String?
+    let algorithm: String?
+    let digits: Int?
     let issuer: String?
-    let period: Int
-    let tokenType: String
+    let period: Int?
+    let tokenType: String?
 }


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-38](https://bitwarden.atlassian.net/browse/BWA-38)

## 📔 Objective

This adjusts the 2FAS import to make all of the "otp" fields optional, as some exports may be missing some of these fields (as opposed to having them and leaving them empty). This should improve the 2FAS import experience.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-38]: https://bitwarden.atlassian.net/browse/BWA-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ