### PR TITLE
Show error alert when attempting to import a password-protected 2fas export

### DIFF
--- a/AuthenticatorShared/Core/Vault/Models/Enum/ImportFormatType.swift
+++ b/AuthenticatorShared/Core/Vault/Models/Enum/ImportFormatType.swift
@@ -61,7 +61,7 @@ enum ImportFormatType: Menuable {
         case .raivoJson:
             "Raivo (JSON)"
         case .twoFasJason:
-            "2FAS (.2fas)"
+            "2FAS (no password)"
         }
     }
 }

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -121,3 +121,4 @@
 "Data" = "Data";
 "Backup" = "Backup";
 "BitwardenAuthenticatorDataIsBackedUpAndCanBeRestored" = "Bitwarden Authenticator data is backed up and can be restored with your regularly scheduled device backups.";
+"ImportingFromTwoFasPasswordProtectedNotSupported" = "Importing from 2FAS password protected files is not supported. Try again with an exported file that is not password protected.";

--- a/AuthenticatorShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -93,4 +93,19 @@ extension Alert {
             ]
         )
     }
+
+    /// An alert notifying the user that we do not currently support password-protected
+    /// files when importing from 2FAS.
+    ///
+    /// - Returns: An alert indicating we don't support password-protected 2FAS files
+    @MainActor
+    static func twoFasPasswordProtected() -> Alert {
+        Alert(
+            title: Localizations.importingFromTwoFasPasswordProtectedNotSupported,
+            message: nil,
+            alertActions: [
+                AlertAction(title: Localizations.ok, style: .default),
+            ]
+        )
+    }
 }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessor.swift
@@ -89,6 +89,8 @@ extension ImportItemsProcessor: FileSelectionDelegate {
                 }
                 try await services.importItemsService.importItems(data: data, format: importFileFormat)
                 state.toast = Toast(text: Localizations.itemsImported)
+            } catch TwoFasImporterError.passwordProtectedFile {
+                coordinator.showAlert(.twoFasPasswordProtected())
             } catch {
                 services.errorReporter.log(error: error)
             }


### PR DESCRIPTION
## 📔 Objective

This updates the 2FAS import flow to detect if the user is trying to import a password-protected export, and provide an error alert if they do indicating we do not currently support that.

## 📸 Screenshots

![Simulator Screenshot - iPhone 15 Pro - 2024-06-12 at 12 38 50](https://github.com/bitwarden/authenticator-ios/assets/159173170/bc9ecda1-3968-4e9c-a49d-b32d1d138ed2)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
