### PR TITLE
Re-enable snapshot tests that work for Xcode 15.4

### DIFF
--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListCardViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListCardViewTests.swift
@@ -9,20 +9,20 @@ import XCTest
 class ItemListCardViewTests: AuthenticatorTestCase {
     // MARK: Tests
 
-//    /// Test a snapshot of the ItemListView previews.
-//    func test_snapshot_ItemListCardView_previews() {
-//        for preview in ItemListCardView_Previews._allPreviews {
-//            let name = preview.displayName ?? "Unknown"
-//            assertSnapshots(
-//                of: preview.content,
-//                as: [
-//                    "\(name)-portrait": .defaultPortrait,
-//                    "\(name)-portraitDark": .defaultPortraitDark,
-//                    "\(name)-portraitAX5": .defaultPortraitAX5,
-//                ]
-//            )
-//        }
-//    }
+    /// Test a snapshot of the ItemListView previews.
+    func test_snapshot_ItemListCardView_previews() {
+        for preview in ItemListCardView_Previews._allPreviews {
+            let name = preview.displayName ?? "Unknown"
+            assertSnapshots(
+                of: preview.content,
+                as: [
+                    "\(name)-portrait": .defaultPortrait,
+                    "\(name)-portraitDark": .defaultPortraitDark,
+                    "\(name)-portraitAX5": .defaultPortraitAX5,
+                ]
+            )
+        }
+    }
 
     /// Test the actions are properly wired up in the ItemListCardView.
     func test_snapshot_ItemListCardView_actions() throws {

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListViewTests.swift
@@ -53,63 +53,63 @@ class ItemListViewTests: AuthenticatorTestCase {
         }
     }
 
-//    /// Test a snapshot of the ItemListView showing the download card with an empty result.
-//    func test_snapshot_ItemListView_card_download_empty() {
-//        let state = ItemListState(
-//            itemListCardState: .passwordManagerDownload,
-//            loadingState: .data([])
-//        )
-//        processor = MockProcessor(state: state)
-//        subject = ItemListView(
-//            store: Store(processor: processor),
-//            timeProvider: timeProvider
-//        )
-//
-//        assertSnapshot(matching: NavigationView { subject }, as: .defaultPortrait)
-//    }
-//
-//    /// Test a snapshot of the ItemListView showing the download card with results.
-//    func test_snapshot_ItemListView_card_download_with_items() {
-//        let state = ItemListState(
-//            itemListCardState: .passwordManagerDownload,
-//            loadingState: .data([ItemListSection.fixture()])
-//        )
-//        processor = MockProcessor(state: state)
-//        subject = ItemListView(
-//            store: Store(processor: processor),
-//            timeProvider: timeProvider
-//        )
-//
-//        assertSnapshot(matching: NavigationView { subject }, as: .defaultPortrait)
-//    }
-//
-//    /// Test a snapshot of the ItemListView showing the sync card with an empty result.
-//    func test_snapshot_ItemListView_card_sync_empty() {
-//        let state = ItemListState(
-//            itemListCardState: .passwordManagerSync,
-//            loadingState: .data([])
-//        )
-//        processor = MockProcessor(state: state)
-//        subject = ItemListView(
-//            store: Store(processor: processor),
-//            timeProvider: timeProvider
-//        )
-//
-//        assertSnapshot(matching: NavigationView { subject }, as: .defaultPortrait)
-//    }
-//
-//    /// Test a snapshot of the ItemListView showing the sync card with results.
-//    func test_snapshot_ItemListView_card_sync_with_items() {
-//        let state = ItemListState(
-//            itemListCardState: .passwordManagerSync,
-//            loadingState: .data([ItemListSection.fixture()])
-//        )
-//        processor = MockProcessor(state: state)
-//        subject = ItemListView(
-//            store: Store(processor: processor),
-//            timeProvider: timeProvider
-//        )
-//
-//        assertSnapshot(matching: NavigationView { subject }, as: .defaultPortrait)
-//    }
+    /// Test a snapshot of the ItemListView showing the download card with an empty result.
+    func test_snapshot_ItemListView_card_download_empty() {
+        let state = ItemListState(
+            itemListCardState: .passwordManagerDownload,
+            loadingState: .data([])
+        )
+        processor = MockProcessor(state: state)
+        subject = ItemListView(
+            store: Store(processor: processor),
+            timeProvider: timeProvider
+        )
+
+        assertSnapshot(matching: NavigationView { subject }, as: .defaultPortrait)
+    }
+
+    /// Test a snapshot of the ItemListView showing the download card with results.
+    func test_snapshot_ItemListView_card_download_with_items() {
+        let state = ItemListState(
+            itemListCardState: .passwordManagerDownload,
+            loadingState: .data([ItemListSection.fixture()])
+        )
+        processor = MockProcessor(state: state)
+        subject = ItemListView(
+            store: Store(processor: processor),
+            timeProvider: timeProvider
+        )
+
+        assertSnapshot(matching: NavigationView { subject }, as: .defaultPortrait)
+    }
+
+    /// Test a snapshot of the ItemListView showing the sync card with an empty result.
+    func test_snapshot_ItemListView_card_sync_empty() {
+        let state = ItemListState(
+            itemListCardState: .passwordManagerSync,
+            loadingState: .data([])
+        )
+        processor = MockProcessor(state: state)
+        subject = ItemListView(
+            store: Store(processor: processor),
+            timeProvider: timeProvider
+        )
+
+        assertSnapshot(matching: NavigationView { subject }, as: .defaultPortrait)
+    }
+
+    /// Test a snapshot of the ItemListView showing the sync card with results.
+    func test_snapshot_ItemListView_card_sync_with_items() {
+        let state = ItemListState(
+            itemListCardState: .passwordManagerSync,
+            loadingState: .data([ItemListSection.fixture()])
+        )
+        processor = MockProcessor(state: state)
+        subject = ItemListView(
+            store: Store(processor: processor),
+            timeProvider: timeProvider
+        )
+
+        assertSnapshot(matching: NavigationView { subject }, as: .defaultPortrait)
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N//A

## 📔 Objective

Now that the GH workflows are using Xcode 15.4, we can add these tests back. (Noted in this [PR](https://github.com/bitwarden/authenticator-ios/pull/145/files#r1751037954))

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
