### PR TITLE
[BITAU-157] Rename Password Manager Sync Feature Flag

### DIFF
--- a/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -8,7 +8,7 @@ enum FeatureFlag: String, Codable {
     // MARK: Feature Flags
 
     /// A feature flag that determines whether or not the password manager sync capability is enabled.
-    case passwordManagerSyncEnabled = "password-manager-sync-enabled"
+    case passwordManagerSyncEnabled = "enable-password-manager-sync-ios"
 
     // MARK: Test Flags
 

--- a/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -8,7 +8,7 @@ enum FeatureFlag: String, Codable {
     // MARK: Feature Flags
 
     /// A feature flag that determines whether or not the password manager sync capability is enabled.
-    case passwordManagerSyncEnabled = "enable-password-manager-sync-ios"
+    case enablePasswordManagerSync = "enable-password-manager-sync-ios"
 
     // MARK: Test Flags
 
@@ -31,7 +31,7 @@ enum FeatureFlag: String, Codable {
     /// but if `isRemotelyConfigured` is false for the flag, then the value here will be used.
     /// This is a helpful way to manage local feature flags.
     static let initialLocalValues: [FeatureFlag: AnyCodable] = [
-        .passwordManagerSyncEnabled: .bool(false),
+        .enablePasswordManagerSync: .bool(false),
         .testLocalBoolFlag: .bool(true),
         .testLocalIntFlag: .int(42),
         .testLocalStringFlag: .string("Test String"),

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -260,7 +260,7 @@ final class ItemListProcessor: StateProcessor<ItemListState, ItemListAction, Ite
     /// Determine if the ItemListCard should be shown and which state to show.
     ///
     private func determineItemListCardState() async {
-        guard await services.configService.getFeatureFlag(.passwordManagerSyncEnabled) else {
+        guard await services.configService.getFeatureFlag(.enablePasswordManagerSync) else {
             state.itemListCardState = .none
             return
         }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -101,7 +101,7 @@ class ItemListProcessorTests: AuthenticatorTestCase {
     /// to false if the feature flag is turned off.
     func test_determineItemListCardState_FeatureFlag_off() {
         subject.state.itemListCardState = .passwordManagerSync
-        configService.featureFlagsBool = [.passwordManagerSyncEnabled: false]
+        configService.featureFlagsBool = [.enablePasswordManagerSync: false]
         let task = Task {
             await self.subject.perform(.appeared)
         }
@@ -112,7 +112,7 @@ class ItemListProcessorTests: AuthenticatorTestCase {
 
     /// Tests that the `itemListCardState` is set to `passwordManagerDownload` if the feature flag is turned on.
     func test_determineItemListCardState_FeatureFlag_on_download() {
-        configService.featureFlagsBool = [.passwordManagerSyncEnabled: true]
+        configService.featureFlagsBool = [.enablePasswordManagerSync: true]
         application.canOpenUrlResponse = false
         let task = Task {
             await self.subject.perform(.appeared)
@@ -124,7 +124,7 @@ class ItemListProcessorTests: AuthenticatorTestCase {
 
     /// Tests that the `itemListCardState` is set to `passwordManagerSync` if the feature flag is turned on.
     func test_determineItemListCardState_FeatureFlag_on_sync() {
-        configService.featureFlagsBool = [.passwordManagerSyncEnabled: true]
+        configService.featureFlagsBool = [.enablePasswordManagerSync: true]
         application.canOpenUrlResponse = true
         let task = Task {
             await self.subject.perform(.appeared)


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-157](https://livefront.atlassian.net/browse/BITAU-157)

## 📔 Objective

This PR brings the feature flag key inline with the naming we just discussed in our feature flag meeting - 1enable-password-manager-sync-ios`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
