### PR TITLE
Qa 895/add-ios-IDs-for-automation

### DIFF
--- a/AuthenticatorShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -103,5 +103,8 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
             .settings(.settings): settingsNavigator,
         ]
         tabNavigator.setNavigators(tabsAndNavigators)
+
+        settingsNavigator.tabBarItem.accessibilityIdentifier = TabRoute.settings(.settings).accessibilityIdentifier
+        itemListNavigator.tabBarItem.accessibilityIdentifier = TabRoute.itemList(.list).accessibilityIdentifier
     }
 }

--- a/AuthenticatorShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -104,7 +104,8 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         ]
         tabNavigator.setNavigators(tabsAndNavigators)
 
-        settingsNavigator.tabBarItem.accessibilityIdentifier = TabRoute.settings(.settings).accessibilityIdentifier
-        itemListNavigator.tabBarItem.accessibilityIdentifier = TabRoute.itemList(.list).accessibilityIdentifier
+        tabsAndNavigators.forEach { key, value in
+            (value as? UINavigationController)?.tabBarItem.accessibilityIdentifier = key.accessibilityIdentifier
+        }
     }
 }

--- a/AuthenticatorShared/UI/Platform/Tabs/TabRoute.swift
+++ b/AuthenticatorShared/UI/Platform/Tabs/TabRoute.swift
@@ -13,8 +13,8 @@ public enum TabRoute: Equatable, Hashable {
 
     public var accessibilityIdentifier: String {
         switch self {
-        case .itemList: return "verificationCodesTabButton"
-        case .settings: return "settingsTabButton"
+        case .itemList: return "VerificationCodesTabButton"
+        case .settings: return "SettingsTabButton"
         }
     }
 }

--- a/AuthenticatorShared/UI/Platform/Tabs/TabRoute.swift
+++ b/AuthenticatorShared/UI/Platform/Tabs/TabRoute.swift
@@ -10,6 +10,13 @@ public enum TabRoute: Equatable, Hashable {
 
     /// The settings tab.
     case settings(SettingsRoute)
+
+    public var accessibilityIdentifier: String {
+        switch self {
+        case .itemList: return "verificationCodesTabButton"
+        case .settings: return "settingsTabButton"
+        }
+    }
 }
 
 // MARK: - TabRepresentable

--- a/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemView.swift
+++ b/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemView.swift
@@ -79,7 +79,6 @@ struct EditAuthenticatorItemView: View {
                 )
             )
             .textFieldConfiguration(.password)
-            //.accessibilityIdentifier("EditItemKeyField")
 
             BitwardenTextField(
                 title: Localizations.username,

--- a/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemView.swift
+++ b/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemView.swift
@@ -63,6 +63,7 @@ struct EditAuthenticatorItemView: View {
                     send: EditAuthenticatorItemAction.issuerChanged
                 )
             )
+            .accessibilityIdentifier("EditItemNameField")
 
             BitwardenTextField(
                 title: Localizations.key,
@@ -70,12 +71,15 @@ struct EditAuthenticatorItemView: View {
                     get: \.secret,
                     send: EditAuthenticatorItemAction.secretChanged
                 ),
+                accessibilityIdentifier: "EditItemKeyField",
+                passwordVisibilityAccessibilityId: "EditKeyVisibilityToggle",
                 isPasswordVisible: store.binding(
                     get: \.isSecretVisible,
                     send: EditAuthenticatorItemAction.toggleSecretVisibilityChanged
                 )
             )
             .textFieldConfiguration(.password)
+            //.accessibilityIdentifier("EditItemKeyField")
 
             BitwardenTextField(
                 title: Localizations.username,
@@ -85,13 +89,14 @@ struct EditAuthenticatorItemView: View {
                 )
             )
             .textFieldConfiguration(.username)
+            .accessibilityIdentifier("EditItemUsernameField")
 
             Toggle(Localizations.favorite, isOn: store.binding(
                 get: \.isFavorited,
                 send: EditAuthenticatorItemAction.favoriteChanged
             ))
             .toggleStyle(.bitwarden)
-            .accessibilityIdentifier("ItemFavoriteToggle")
+            .accessibilityIdentifier("EditItemFavoriteToggle")
         }
     }
 
@@ -163,7 +168,7 @@ struct EditAuthenticatorItemView: View {
         AsyncButton(Localizations.save) {
             await store.perform(.savePressed)
         }
-        .accessibilityIdentifier("SaveButton")
+        .accessibilityIdentifier("EditItemSaveButton")
         .buttonStyle(.primary())
     }
 
@@ -171,7 +176,7 @@ struct EditAuthenticatorItemView: View {
         AsyncButton(Localizations.delete) {
             await store.perform(.deletePressed)
         }
-        .accessibilityIdentifier("DeleteButton")
+        .accessibilityIdentifier("EditItemDeleteButton")
         .buttonStyle(.tertiary(isDestructive: true))
     }
 }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -115,6 +115,7 @@ private struct SearchableItemListView: View {
 
                     Spacer()
                 }
+                .accessibilityIdentifier("emptyVaultAddCodeButton")
                 .padding(.horizontal, 16)
                 .frame(minWidth: reader.size.width, minHeight: reader.size.height)
             }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -115,7 +115,7 @@ private struct SearchableItemListView: View {
 
                     Spacer()
                 }
-                .accessibilityIdentifier("emptyVaultAddCodeButton")
+                .accessibilityIdentifier("EmptyVaultAddCodeButton")
                 .padding(.horizontal, 16)
                 .frame(minWidth: reader.size.width, minHeight: reader.size.height)
             }

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryView.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryView.swift
@@ -35,6 +35,7 @@ struct ManualEntryView: View {
             )
         }
         .buttonStyle(.tertiary())
+        .accessibilityIdentifier("manualEntryAddCodeButton")
     }
 
     /// The main content of the view.
@@ -50,6 +51,7 @@ struct ManualEntryView: View {
                     send: ManualEntryAction.nameChanged
                 )
             )
+            .accessibilityIdentifier("ManualEntryNameField")
 
             BitwardenTextField(
                 title: Localizations.key,
@@ -58,6 +60,7 @@ struct ManualEntryView: View {
                     send: ManualEntryAction.authenticatorKeyChanged
                 )
             )
+            .accessibilityIdentifier("ManualEntryKeyField")
             addButton
             footer
         }

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryView.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryView.swift
@@ -35,7 +35,7 @@ struct ManualEntryView: View {
             )
         }
         .buttonStyle(.tertiary())
-        .accessibilityIdentifier("manualEntryAddCodeButton")
+        .accessibilityIdentifier("ManualEntryAddCodeButton")
     }
 
     /// The main content of the view.


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/QA-895

## 📔 Objective
add unique IDs to interactable elements to enable test automation of the iOS authenticator app

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
