### PR TITLE
Fix for build failures when building without the DEBUG_MENU flag on

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
@@ -78,7 +78,9 @@ class AppCoordinator: Coordinator, HasRootNavigator {
     func navigate(to route: AppRoute, context _: AnyObject?) {
         switch route {
         case .debugMenu:
+            #if DEBUG_MENU
             showDebugMenu()
+            #endif
         case let .tab(tabRoute):
             showTab(route: tabRoute)
         }


### PR DESCRIPTION
## 🎟️ Tracking

No issue for this.

## 📔 Objective

I noticed when building some Production test builds for Luke that our builds were failing. There's one place where we're calling a method that's conditionally included, but the call location is not conditional (on the `DEBUG_MENU` flag). This is causing builds to fail _unless_ they have `DEBUG_MENU` declared on.

I've already included this change in my feature branch I'm using for builds and [it fixed the issue in this build](https://github.com/bitwarden/authenticator-ios/actions/runs/11632234828).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
