### PR TITLE
[BWA-78] Space in Manually Entered Key Fails

### DIFF
--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPCodeConfigTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPCodeConfigTests.swift
@@ -32,6 +32,15 @@ final class TOTPCodeConfigTests: AuthenticatorTestCase {
         XCTAssertEqual(subject?.base32Key, .base32Key)
     }
 
+    /// Tests that a base32 string with spaces creates the model with the spaces removed.
+    func test_init_totpCodeConfig_base32_withSpaces() {
+        let subject = TOTPKeyModel(
+            authenticatorKey: .base32KeyWithSpaces
+        )
+        XCTAssertNotNil(subject)
+        XCTAssertEqual(subject?.base32Key, .base32Key)
+    }
+
     /// Tests that an otp auth string creates the model.
     func test_init_totpCodeConfig_success_full() {
         let subject = TOTPKeyModel(

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPKey.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPKey.swift
@@ -89,8 +89,8 @@ enum TOTPKey: Equatable {
     ///
     /// - Parameter key: A string representing the TOTP key.
     init?(_ key: String) {
-        if key.uppercased().isBase32 {
-            self = .base32(key: key)
+        if key.uppercased().whitespaceRemoved().isBase32 {
+            self = .base32(key: key.uppercased().whitespaceRemoved())
         } else if key.hasOTPAuthPrefix,
                   let otpAuthModel = OTPAuthModel(otpAuthUri: key) {
             self = .otpAuthUri(otpAuthModel)

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/String+TOTPFixtures.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/String+TOTPFixtures.swift
@@ -2,6 +2,7 @@
 
 extension String {
     static let base32Key = "JBSWY3DPEHPK3PXP"
+    static let base32KeyWithSpaces = "JBSW Y3DP EHPK 3PXP"
     // swiftlint:disable:next line_length
     static let otpAuthUriKeyComplete = "otpauth://totp/Example:eliot@livefront.com?secret=JBSWY3DPEHPK3PXP&issuer=Example&algorithm=SHA256&digits=6&period=30"
     static let otpAuthUriKeyPartial = "otpauth://totp/Example:eliot@livefront.com?secret=JBSWY3DPEHPK3PXP"

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/String.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/String.swift
@@ -130,4 +130,12 @@ extension String {
                 count: remainder == 0 ? 0 : 4 - remainder
             ))
     }
+
+    /// Returns a copy of the string with all of the whitespace characters removed.
+    ///
+    /// - Returns: a copy of the string with all of the whitespace characters removed.
+    ///
+    func whitespaceRemoved() -> String {
+        replacingOccurrences(of: "\\s", with: "", options: .regularExpression)
+    }
 }

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/StringTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/StringTests.swift
@@ -104,4 +104,11 @@ class StringTests: AuthenticatorTestCase {
 
         XCTAssertEqual(encoded, "a_bcd-")
     }
+
+    func test_whitespaceRemoved() {
+        let subject = "  N  o  Whi te  Space   "
+        let expected = "NoWhiteSpace"
+
+        XCTAssertEqual(expected, subject.whitespaceRemoved())
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-78](https://bitwarden.atlassian.net/browse/BWA-78)

## 📔 Objective

This PR adds handling for codes with spaces inside them when the user is manually entering codes. Previously, we would fail to read the code if it was a valid code but had spaces - e.g. `7NLT E5DK QQZG BEIV`.

### Notes

The PM app handles these codes because there was a refactor done back in July to make `TOTPKey.init` non-optional. It does not check `.isBase32` but rather stores any string as a `.standard` code if it is not otpauth or SteamURI. I was seeing that cause issues on my other PR in the PM app and I think it would cause issues here as well, so I made this a targeted refactor just to solve this specific issue. 

I do, however, think we want to look in the future at how to share code between the two apps for these common pieces. This is a good example of an upgrade Authenticator would have inherited from shared code.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
