### PR TITLE
[BWA-71] Order of Entries Shuffles on Token Refresh

### DIFF
--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -316,7 +316,8 @@ final class ItemListProcessor: StateProcessor<ItemListState, ItemListAction, Ite
                         showToast = true
                     }
                     let itemList = try await services.authenticatorItemRepository.refreshTotpCodes(on: section.items)
-                    return ItemListSection(id: section.id, items: itemList, name: section.name)
+                    let sortedList = itemList.sorted { $0.name < $1.name }
+                    return ItemListSection(id: section.id, items: sortedList, name: section.name)
                 }
                 groupTotpExpirationManager?.configureTOTPRefreshScheduling(for: sectionList.flatMap(\.items))
                 state.showMoveToBitwarden = await services.authenticatorItemRepository.isPasswordManagerSyncActive()


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-71](https://bitwarden.atlassian.net/browse/BWA-71)

## 📔 Objective

This PR sorts the Item List by `.name` to prevent items from "jumping" when the TOTP codes are refreshed. Previously, the items were not sorted in any way. So when a refresh happened, there was no guarantee that an item would stay in the same place. Sorting by name also makes the list easier to scan and find what you're looking for.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-71]: https://bitwarden.atlassian.net/browse/BWA-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ