### PR TITLE
[BITAU-216] Change Move to Copy in Long Press Menu

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -129,7 +129,7 @@
 "SyncWithBitwardenApp" = "Sync with Bitwarden app";
 "LocalCodes" = "Local codes";
 "AccountsSyncedFromBitwardenApp" = "Accounts synced from Bitwarden app";
-"MoveToBitwarden" = "Move to Bitwarden";
+"CopyToBitwarden" = "Copy to Bitwarden";
 "ScanComplete" = "Scan complete";
 "SaveThisAuthenticatorKeyHereOrAddItToALoginInYourBitwardenApp" = "Save this authenticator key here, or add it to a login in your Bitwarden app.";
 "SaveHere" = "Save here";

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -239,7 +239,7 @@ private struct SearchableItemListView: View {
                                 await store.perform(.moveToBitwardenPressed(item))
                             } label: {
                                 HStack(spacing: 4) {
-                                    Text(Localizations.moveToBitwarden)
+                                    Text(Localizations.copyToBitwarden)
                                     Spacer()
                                     Image(decorative: Asset.Images.rightArrow)
                                         .imageStyle(.accessoryIcon(scaleWithFont: true))


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-216](https://livefront.atlassian.net/browse/BITAU-216)

## 📔 Objective

Minor copy change: "Move to Bitwarden" is changed to "Copy to Bitwarden" in the long press menu. The functionality is currently more of a copy than a move (i.e. the local code isn't deleted automatically) so Emily/Matt wanted to reflect that a little better in our menu.

## 📸 Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-11-21 at 16 35 07](https://github.com/user-attachments/assets/6f0f5151-cfdf-4782-bd26-b2f4cc8572b7)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
