### PR TITLE
[BWA-46] Fix: Export Items Crashes on iPad

### DIFF
--- a/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -108,6 +108,11 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
                 self.showToast(Localizations.itemsExported)
             }
         }
+        if let popoverController = activityVC.popoverPresentationController {
+            popoverController.sourceView = stackNavigator?.rootViewController?.view
+            popoverController.permittedArrowDirections = []
+        }
+
         stackNavigator?.present(activityVC)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-46](https://bitwarden.atlassian.net/browse/BWA-46)

## 📔 Objective

This PR is a fix for a crashing bug in the Export Items flow, when running on an iPad. In iPadOS, presenting a `UIActivityViewController` will crash if you don't set a `sourceView` on the `popoverPresentationController`. On IOS, the `popoverPresentationController` is `nil` and you don't need to do anything else to get a modal presentation. This fix is simply setting the `sourceView` if `popoverPresentationController` is not `nil` and then giving it an empty array for `permittedArrowDirections` which tells it that it needs to present centered, modally (like on iOS).

## 📸 Screenshots
![Simulator Screenshot - iPad (10th generation) - 2024-12-05 at 09 56 09](https://github.com/user-attachments/assets/a0f56483-e960-439a-b474-633f30ed4734)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-46]: https://bitwarden.atlassian.net/browse/BWA-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ