### PR TITLE
[BITAU-218] Remove Pull to Refresh

### DIFF
--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -2,22 +2,6 @@
 
 import SwiftUI
 
-// MARK: - PreserveLargeTitleView
-
-/// A view that prevents the `.large` title from scrolling into `.inline` mode.
-///
-/// By adding this view to the hierarchy, it moves the activity indicator underneath the nav bar,
-/// keeping the title and search bar in place while the refreshable happens below.
-///
-private struct PreserveLargeTitleView: View {
-    var body: some View {
-        Rectangle()
-            .fill(Color(UIColor(white: 0.0, alpha: 0.0005)))
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 1)
-            .hidden()
-    }
-}
-
 // MARK: - SearchableItemListView
 
 /// A view that displays the items in a single vault group.
@@ -372,9 +356,6 @@ struct ItemListView: View {
             )
             .task(id: store.state.searchText) {
                 await store.perform(.search(store.state.searchText))
-            }
-            .refreshable {
-                await store.perform(.refresh)
             }
         }
         .navigationTitle(Localizations.verificationCodes)


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-218](https://livefront.atlassian.net/browse/BITAU-218)

## 📔 Objective

With all of the problems with pull to refresh (space left at the top, jumpy scrolling when that was fixed, line in the UI when trying to hack around inline titles, etc), I discussed the problem with Emily ands made the call to remove Pull to Refresh. We technically shouldn't need pull-to-refresh on the Authenticator app since we don't have a server to load from and the local values are listening to a publisher. 

This change has been made _just_ to the view - i.e. removing the `refreshable` call, but not the effect and implementation in the processor. This makes it easy to revert if we find that this causes confusion or isn't a good long term solution.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
