### PR TITLE
[BWA-82] Don't Timeout When User Selects Never

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/StateService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/StateService.swift
@@ -70,6 +70,12 @@ protocol StateService: AnyObject {
     ///
     func getShowWebIcons() async -> Bool
 
+    /// Gets the session timeout value for the logged in user.
+    ///
+    /// - Returns: The session timeout value.
+    ///
+    func getVaultTimeout() async -> SessionTimeoutValue
+
     /// Sets the app theme.
     ///
     /// - Parameter appTheme: The new app theme.
@@ -238,6 +244,13 @@ actor DefaultStateService: StateService {
 
     func getShowWebIcons() async -> Bool {
         !appSettingsStore.disableWebIcons
+    }
+
+    func getVaultTimeout() async -> SessionTimeoutValue {
+        let accountId = await getActiveAccountId()
+        guard let rawValue = appSettingsStore.vaultTimeout(userId: accountId) else { return .never }
+
+        return SessionTimeoutValue(rawValue: rawValue)
     }
 
     func setAppTheme(_ appTheme: AppTheme) async {

--- a/AuthenticatorShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -24,6 +24,7 @@ class MockStateService: StateService {
     var timeProvider = MockTimeProvider(.currentTime)
     var showWebIcons = true
     var showWebIconsSubject = CurrentValueSubject<Bool, Never>(true)
+    var vaultTimeout = SessionTimeoutValue.never
 
     lazy var appThemeSubject = CurrentValueSubject<AppTheme, Never>(self.appTheme ?? .default)
 
@@ -52,6 +53,10 @@ class MockStateService: StateService {
 
     func getShowWebIcons() async -> Bool {
         showWebIcons
+    }
+
+    func getVaultTimeout() async -> SessionTimeoutValue {
+        vaultTimeout
     }
 
     func setAppTheme(_ appTheme: AppTheme) async {

--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
@@ -63,8 +63,12 @@ class AppCoordinator: Coordinator, HasRootNavigator {
     func handleEvent(_ event: AppEvent, context: AnyObject?) async {
         switch event {
         case .didStart:
+            let accountId = await services.stateService.getActiveAccountId()
+            let hasTimeout = services.appSettingsStore.vaultTimeout(userId: accountId) !=
+                SessionTimeoutValue.never.rawValue
             let isEnabled = await (try? services.biometricsRepository.getBiometricUnlockStatus().isEnabled) ?? false
-            if isEnabled {
+
+            if isEnabled, hasTimeout {
                 showAuth(.vaultUnlock)
             } else {
                 showTab(route: .itemList(.list))

--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
@@ -63,9 +63,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
     func handleEvent(_ event: AppEvent, context: AnyObject?) async {
         switch event {
         case .didStart:
-            let accountId = await services.stateService.getActiveAccountId()
-            let hasTimeout = services.appSettingsStore.vaultTimeout(userId: accountId) !=
-                SessionTimeoutValue.never.rawValue
+            let hasTimeout = await services.stateService.getVaultTimeout() != .never
             let isEnabled = await (try? services.biometricsRepository.getBiometricUnlockStatus().isEnabled) ?? false
 
             if isEnabled, hasTimeout {


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-82](https://bitwarden.atlassian.net/browse/BWA-82)

## 📔 Objective

This PR fixes an issue where a user who has biometric authentication turned on, but selects "Never" as their timeout duration would still be prompted for biometrics when the app was closed and re-opened. This PR adds an additional check on startup to allow the user to bypass biometric authentication if they have selected "Never".

## 📸 Screenshots

https://github.com/user-attachments/assets/cad9884e-fd51-40fd-81ec-a613060b9f34

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-82]: https://bitwarden.atlassian.net/browse/BWA-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ