### PR TITLE
[BWA-125] Handle Sorting When Issuer Name Is Empty

### DIFF
--- a/AuthenticatorShared/UI/Vault/Extensions/Array+TOTPHelpers.swift
+++ b/AuthenticatorShared/UI/Vault/Extensions/Array+TOTPHelpers.swift
@@ -29,7 +29,7 @@ extension [ItemListItem] {
             }
         }
         return result.values
-            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+            .sorted(by: ItemListItem.localizedNameComparator)
     }
 }
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
@@ -160,6 +160,32 @@ extension ItemListItem {
     }
 }
 
+extension ItemListItem {
+    /// A comparator to use for sorting that will sort based on the localized compare of the two item's names.
+    /// If the name is blank (e.g. an otpauth style code with no issuer) it will fall back to account name.
+    ///
+    /// If the names are equal, we default to comparing the two ids. This is to prevent items with the same
+    /// name/issuer from "jumping" around when the list is sorted.
+    ///
+    /// - Parameters:
+    ///   - lhs: The left hand item of the comparison
+    ///   - rhs: The right hand item of the comparison
+    /// - Returns: `true` if  `lhs < rhs` according to the compare. `false` otherwise.
+    ///
+    static func localizedNameComparator(lhs: ItemListItem, rhs: ItemListItem) -> Bool {
+        let leftName = lhs.name.nilIfEmpty ?? lhs.accountName ?? ""
+        let rightName = rhs.name.nilIfEmpty ?? rhs.accountName ?? ""
+
+        if leftName == rightName {
+            return lhs.id < rhs.id
+        } else {
+            return leftName.localizedStandardCompare(rightName) == .orderedAscending
+        }
+    }
+}
+
+// MARK: - ItemListTotpItem
+
 public struct ItemListTotpItem: Equatable {
     /// The `AuthenticatorItemView` used to populate the view
     let itemView: AuthenticatorItemView
@@ -167,6 +193,8 @@ public struct ItemListTotpItem: Equatable {
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel
 }
+
+// MARK: - ItemListSharedTotpItem
 
 public struct ItemListSharedTotpItem: Equatable {
     /// The `AuthenticatorBridgeItemDataView` used to populate the view

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItemTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItemTests.swift
@@ -7,6 +7,19 @@ import XCTest
 class ItemListItemTests: AuthenticatorTestCase {
     var subject: ItemListItem!
 
+    func test_localizedNameComparator() {
+        let alpha = ItemListItem.fixture(name: "alpha")
+        let alphaCaps = ItemListItem.fixture(name: "ALPHA")
+        let beta = ItemListItem.fixture(name: "beta")
+        let blankNameAlpha = ItemListItem.fixture(name: "", accountName: "alpha")
+        let blankBoth = ItemListItem.fixtureShared(name: "", accountName: nil)
+
+        let expected = [blankBoth, alpha, blankNameAlpha, alphaCaps, beta]
+        let list = [beta, alphaCaps, alpha, blankNameAlpha, blankBoth]
+
+        XCTAssertEqual(list.sorted(by: ItemListItem.localizedNameComparator), expected)
+    }
+
     /// `totpCodeModel` returns the associated `TOTPCodeModel` for an item of type `.sharedTotp`.
     func test_totpCodeModel_shared() {
         let expected = TOTPCodeModel(code: "098765", codeGenerationDate: .now, period: 30)

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -317,7 +317,7 @@ final class ItemListProcessor: StateProcessor<ItemListState, ItemListAction, Ite
                         showToast = true
                     }
                     let itemList = try await services.authenticatorItemRepository.refreshTotpCodes(on: section.items)
-                    let sortedList = itemList.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+                    let sortedList = itemList.sorted(by: ItemListItem.localizedNameComparator)
                     return ItemListSection(id: section.id, items: sortedList, name: section.name)
                 }
                 groupTotpExpirationManager?.configureTOTPRefreshScheduling(for: sectionList.flatMap(\.items))

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -502,11 +502,15 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
             ItemListItem.fixture(name: "Delta"),
             ItemListItem.fixture(name: "Alpha"),
             ItemListItem.fixture(name: "beta"),
+            ItemListItem.fixtureShared(name: "", accountName: nil),
+            ItemListItem.fixture(name: "", accountName: "delta"),
         ]
         let resultsSorted = [
+            results[5], // name and account name blank
             results[3], // Alpha
             results[4], // beta
             results[1], // Beta
+            results[6], // delta (account name, name is blank)
             results[2], // Delta
             results[0], // Gamma
         ]


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-125](https://bitwarden.atlassian.net/browse/BWA-125)

## 📔 Objective

In fixing [BWA-71](https://bitwarden.atlassian.net/browse/BWA-71) we added sorting based on the item's name. This solved most of the issues where codes would jump around in the list. However, there was still an issue when the issuer of an `otpauth` style code was blank (i.e. `""`). This would result in a blank `name`, which is the value we're comparing, but the `accountName` would be displayed instead. For instance, if you had a blank `name`, but an `accountName` of `"ZZZZ"`, that would sort to the top, which in the UI looks very wrong.

This PR adds a more in-depth sort comparator. If the name/issuer is blank, we fall back to the `accountName` for the sorting comparison. This matches what the UI is displaying, so it sorts the list as visually expected. 

It also adds a fallback comparison. If we end up with two names that are actually equal, this could mean those two items could switch places in a sort. This causes them to "jump" in the list (e.g. when codes are refreshed). To avoid these re-ordering dynamically, we add one last compare of the `id`s. That deterministically sorts them to keep order consistent across updates.

### Testing Note
This can only be reproduced by QR code scanning. The manual entry form enforces that the name be present **and not blank**. That means there's no way to test this other than making QR codes that have a missing issuer.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-125]: https://bitwarden.atlassian.net/browse/BWA-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BWA-71]: https://bitwarden.atlassian.net/browse/BWA-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ