### PR TITLE
[PM-16666] Enable remote configuration of password manager sync feature flag

### DIFF
--- a/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -62,13 +62,13 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// Whether this feature can be enabled remotely.
     var isRemotelyConfigured: Bool {
         switch self {
-        case .enablePasswordManagerSync,
-             .testLocalFeatureFlag,
+        case .testLocalFeatureFlag,
              .testLocalInitialBoolFlag,
              .testLocalInitialIntFlag,
              .testLocalInitialStringFlag:
             false
-        case .testRemoteFeatureFlag,
+        case .enablePasswordManagerSync,
+             .testRemoteFeatureFlag,
              .testRemoteInitialBoolFlag,
              .testRemoteInitialIntFlag,
              .testRemoteInitialStringFlag:

--- a/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -12,6 +12,20 @@ final class FeatureFlagTests: AuthenticatorTestCase {
         XCTAssertEqual(filtered, [])
     }
 
+    /// `isRemotelyConfigured` returns the correct value for each flag.
+    func test_isRemotelyConfigured() {
+        XCTAssertTrue(FeatureFlag.enablePasswordManagerSync.isRemotelyConfigured)
+        XCTAssertTrue(FeatureFlag.testRemoteFeatureFlag.isRemotelyConfigured)
+        XCTAssertTrue(FeatureFlag.testRemoteInitialBoolFlag.isRemotelyConfigured)
+        XCTAssertTrue(FeatureFlag.testRemoteInitialIntFlag.isRemotelyConfigured)
+        XCTAssertTrue(FeatureFlag.testRemoteInitialStringFlag.isRemotelyConfigured)
+
+        XCTAssertFalse(FeatureFlag.testLocalFeatureFlag.isRemotelyConfigured)
+        XCTAssertFalse(FeatureFlag.testLocalInitialBoolFlag.isRemotelyConfigured)
+        XCTAssertFalse(FeatureFlag.testLocalInitialIntFlag.isRemotelyConfigured)
+        XCTAssertFalse(FeatureFlag.testLocalInitialStringFlag.isRemotelyConfigured)
+    }
+
     /// `name` formats the raw value of a feature flag
     func test_name() {
         XCTAssertEqual(FeatureFlag.testLocalFeatureFlag.name, "Test Local Feature Flag")


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-16666](https://bitwarden.atlassian.net/browse/PM-16666)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enables the password manager sync feature flag to be remotely configured.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16666]: https://bitwarden.atlassian.net/browse/PM-16666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ